### PR TITLE
JWK clients should use HTTPS

### DIFF
--- a/jose_test.go
+++ b/jose_test.go
@@ -99,3 +99,12 @@ func TestTokenSignatureValidator(t *testing.T) {
 		t.Errorf("unexpected body: %s", body)
 	}
 }
+
+func Test_newValidator_unkownAlg(t *testing.T) {
+	_, err := newValidator(&signatureConfig{
+		Alg: "random",
+	})
+	if err == nil || err.Error() != "JOSE: unknown algorithm random" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
Instead of throwing a warning as suggested at #6 , this PR introduces a new param `disable_jwk_security` at both config types - signer and verifier - so the config parsers will return an error if the URL of the JWK service is not HTTPS and the JWK Security has not been disabled at the configuration