### PR TITLE
Add support for Public Key Pinning

### DIFF
--- a/jose.go
+++ b/jose.go
@@ -126,9 +126,21 @@ func newValidator(scfg *signatureConfig) (*auth0.JWTValidator, error) {
 		auth0.RequestTokenExtractorFunc(FromCookie(scfg.CookieKey)),
 	)
 
+	decodedFs, err := decodeFingerprints(scfg.Fingerprints)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := secretProviderConfig{
+		URI:          scfg.URI,
+		cacheEnabled: scfg.CacheEnabled,
+		cs:           scfg.CipherSuites,
+		fingerprints: decodedFs,
+	}
+
 	return auth0.NewValidator(
 		auth0.NewConfiguration(
-			secretProvider(scfg.URI, scfg.CacheEnabled, scfg.CipherSuites, te),
+			secretProvider(cfg, te),
 			scfg.Audience,
 			scfg.Issuer,
 			sa,

--- a/jwk.go
+++ b/jwk.go
@@ -1,7 +1,15 @@
 package jose
 
 import (
+	"bytes"
+	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"time"
@@ -9,40 +17,113 @@ import (
 	auth0 "github.com/auth0-community/go-auth0"
 )
 
-func secretProvider(URI string, cacheEnabled bool, cs []uint16, te auth0.RequestTokenExtractor) *auth0.JWKClient {
-	if len(cs) == 0 {
-		cs = DefaultEnabledCipherSuites
+type secretProviderConfig struct {
+	URI          string
+	cacheEnabled bool
+	fingerprints [][]byte
+	cs           []uint16
+}
+
+var (
+	ErrInsecureJWKSource = errors.New("JWK client is using an insecure connection to the JWK service")
+	ErrPinnedKeyNotFound = errors.New("JWK client did not find a pinned key")
+)
+
+func secretProvider(cfg secretProviderConfig, te auth0.RequestTokenExtractor) *auth0.JWKClient {
+	if len(cfg.cs) == 0 {
+		cfg.cs = DefaultEnabledCipherSuites
 	}
 
-	tlsConfig := &tls.Config{
-		CipherSuites: cs,
-		MinVersion:   tls.VersionTLS12,
-	}
+	dialer := NewDialer(cfg)
 
-	opts := auth0.JWKClientOptions{
-		URI: URI,
-		Client: &http.Client{
-			Transport: &http.Transport{
-				Proxy: http.ProxyFromEnvironment,
-				DialContext: (&net.Dialer{
-					Timeout:   30 * time.Second,
-					KeepAlive: 30 * time.Second,
-					DualStack: true,
-				}).DialContext,
-				MaxIdleConns:          10,
-				IdleConnTimeout:       90 * time.Second,
-				TLSHandshakeTimeout:   10 * time.Second,
-				ExpectContinueTimeout: 1 * time.Second,
-				TLSClientConfig:       tlsConfig,
-			},
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		MaxIdleConns:          10,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig: &tls.Config{
+			CipherSuites: cfg.cs,
+			MinVersion:   tls.VersionTLS12,
 		},
 	}
 
-	if !cacheEnabled {
+	if len(cfg.fingerprints) > 0 {
+		transport.DialTLS = dialer.DialTLS
+	}
+
+	opts := auth0.JWKClientOptions{
+		URI: cfg.URI,
+		Client: &http.Client{
+			Transport: transport,
+		},
+	}
+
+	if !cfg.cacheEnabled {
 		return auth0.NewJWKClient(opts, te)
 	}
 	keyCacher := auth0.NewMemoryKeyCacher(15*time.Minute, 100)
 	return auth0.NewJWKClientWithCache(opts, te, keyCacher)
+}
+
+func decodeFingerprints(in []string) ([][]byte, error) {
+	out := make([][]byte, len(in))
+	for i, f := range in {
+		r, err := base64.URLEncoding.DecodeString(f)
+		if err != nil {
+			return out, fmt.Errorf("decoding fingerprint #%d: %s", i, err.Error())
+		}
+		out[i] = r
+	}
+	return out, nil
+}
+
+func NewDialer(cfg secretProviderConfig) *Dialer {
+	return &Dialer{
+		dialer: &net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		},
+		fingerprints: cfg.fingerprints,
+	}
+}
+
+type Dialer struct {
+	dialer             *net.Dialer
+	fingerprints       [][]byte
+	skipCAVerification bool
+}
+
+func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return d.dialer.DialContext(ctx, network, address)
+}
+
+func (d *Dialer) DialTLS(network, addr string) (net.Conn, error) {
+	c, err := tls.Dial(network, addr, &tls.Config{InsecureSkipVerify: d.skipCAVerification})
+	if err != nil {
+		return nil, err
+	}
+	connstate := c.ConnectionState()
+	keyPinValid := false
+	for _, peercert := range connstate.PeerCertificates {
+		der, err := x509.MarshalPKIXPublicKey(peercert.PublicKey)
+		hash := sha256.Sum256(der)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, fingerprint := range d.fingerprints {
+			if bytes.Compare(hash[0:], fingerprint) == 0 {
+				keyPinValid = true
+				break
+			}
+		}
+	}
+	if keyPinValid == false {
+		return nil, ErrPinnedKeyNotFound
+	}
+	return c, nil
 }
 
 var (

--- a/jwk_example_test.go
+++ b/jwk_example_test.go
@@ -1,0 +1,38 @@
+// +build integration
+
+package jose
+
+import "fmt"
+
+func Example_Auth0Integration() {
+	fs, _ := decodeFingerprints([]string{"--MBgDH5WGvL9Bcn5Be30cRcL0f5O-NyoXuWtQdX1aI="})
+	cfg := secretProviderConfig{
+		URI:          "https://albert-test.auth0.com/.well-known/jwks.json",
+		fingerprints: fs,
+	}
+	client := secretProvider(cfg, nil)
+
+	k, err := client.GetKey("MDNGMjU2M0U3RERFQUEwOUUzQUMwQ0NBN0Y1RUY0OEIxNTRDM0IxMw")
+	fmt.Println("err:", err)
+	fmt.Println("is public:", k.IsPublic())
+	fmt.Println("alg:", k.Algorithm)
+	fmt.Println("id:", k.KeyID)
+	// Output:
+	// err: <nil>
+	// is public: true
+	// alg: RS256
+	// id: MDNGMjU2M0U3RERFQUEwOUUzQUMwQ0NBN0Y1RUY0OEIxNTRDM0IxMw
+}
+
+func Example_Auth0Integration_badFingerprint() {
+	cfg := secretProviderConfig{
+		URI:          "https://albert-test.auth0.com/.well-known/jwks.json",
+		fingerprints: [][]byte{make([]byte, 32)},
+	}
+	client := secretProvider(cfg, nil)
+
+	_, err := client.GetKey("MDNGMjU2M0U3RERFQUEwOUUzQUMwQ0NBN0Y1RUY0OEIxNTRDM0IxMw")
+	fmt.Println("err:", err)
+	// Output:
+	// err: Get https://albert-test.auth0.com/.well-known/jwks.json: JWK client did not find a pinned key
+}

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -39,8 +39,7 @@ func TestJWK(t *testing.T) {
 	} {
 		server := httptest.NewServer(jwkEndpoint(tc.Name))
 		defer server.Close()
-
-		secretProvidr := secretProvider(server.URL, false, []uint16{}, nil)
+		secretProvidr := secretProvider(secretProviderConfig{URI: server.URL}, nil)
 		for _, k := range tc.ID {
 			key, err := secretProvidr.GetKey(k)
 			if err != nil {
@@ -50,6 +49,24 @@ func TestJWK(t *testing.T) {
 				t.Errorf("wrong alg. have: %s, want: %s", key.Algorithm, tc.Alg)
 			}
 		}
+	}
+}
+
+func TestDialer_DialTLS_ko(t *testing.T) {
+	d := NewDialer(secretProviderConfig{})
+	c, err := d.DialTLS("\t", "addr")
+	if err == nil {
+		t.Error(err)
+	}
+	if c != nil {
+		t.Errorf("unexpected connection: %v", c)
+	}
+}
+
+func Test_decodeFingerprints(t *testing.T) {
+	_, err := decodeFingerprints([]string{"not_encoded_message"})
+	if err == nil {
+		t.Error(err)
 	}
 }
 

--- a/jws_test.go
+++ b/jws_test.go
@@ -189,7 +189,7 @@ func testPrivateSigner(t *testing.T, keyType, keyName, full, compact string) {
 	server := httptest.NewServer(jwkEndpoint(keyType))
 	defer server.Close()
 
-	sp := secretProvider(server.URL, false, []uint16{}, nil)
+	sp := secretProvider(secretProviderConfig{URI: server.URL}, nil)
 	key, err := sp.GetKey(keyName)
 	if err != nil {
 		t.Errorf("getting the key: %s", err.Error())


### PR DESCRIPTION
as requested in #3 , this PR adds support for public key pinning for the JWK client.

The feature is enabled if one or more key fingerprints are added to the endpoint configs