### PR TITLE
support for local CA added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor
 coverage.out
+cert.pem
+key.pem

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,5 @@ deps:
 	dep status
 
 test:
+	go generate
 	go test -cover ./...

--- a/jose.go
+++ b/jose.go
@@ -28,15 +28,22 @@ func NewValidator(signatureConfig *SignatureConfig, ef ExtractorFactory) (*auth0
 	}
 
 	cfg := SecretProviderConfig{
-		URI:          signatureConfig.URI,
-		CacheEnabled: signatureConfig.CacheEnabled,
-		Cs:           signatureConfig.CipherSuites,
-		Fingerprints: decodedFs,
+		URI:           signatureConfig.URI,
+		CacheEnabled:  signatureConfig.CacheEnabled,
+		Cs:            signatureConfig.CipherSuites,
+		Fingerprints:  decodedFs,
+		LocalCA:       signatureConfig.LocalCA,
+		AllowInsecure: signatureConfig.DisableJWKSecurity,
+	}
+
+	sp, err := SecretProvider(cfg, te)
+	if err != nil {
+		return nil, err
 	}
 
 	return auth0.NewValidator(
 		auth0.NewConfiguration(
-			SecretProvider(cfg, te),
+			sp,
 			signatureConfig.Audience,
 			signatureConfig.Issuer,
 			sa,

--- a/jws_test.go
+++ b/jws_test.go
@@ -189,7 +189,11 @@ func testPrivateSigner(t *testing.T, keyType, keyName, full, compact string) {
 	server := httptest.NewServer(jwkEndpoint(keyType))
 	defer server.Close()
 
-	sp := SecretProvider(SecretProviderConfig{URI: server.URL}, nil)
+	sp, err := SecretProvider(SecretProviderConfig{URI: server.URL}, nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 	key, err := sp.GetKey(keyName)
 	if err != nil {
 		t.Errorf("getting the key: %s", err.Error())


### PR DESCRIPTION
this PR introduces a new config param `jwk_local_ca` for the verifier and signer middlewares so users can use certs not included into the system CA with the JWK client