### PR TITLE
use JWK Algorithm instead of config Alg

### DIFF
--- a/jws.go
+++ b/jws.go
@@ -34,7 +34,7 @@ type SignatureConfig struct {
 }
 
 type SignerConfig struct {
-	Alg                string   `json:"alg"`
+	Alg                string   `json:"alg,omitempty"`
 	KeyID              string   `json:"kid"`
 	URI                string   `json:"jwk-url"`
 	FullSerialization  bool     `json:"full,omitempty"`
@@ -116,9 +116,15 @@ func NewSigner(cfg *config.EndpointConfig, te auth0.RequestTokenExtractor) (*Sig
 	if key.IsPublic() {
 		// TODO: we should not sign with a public key
 	}
+
+	alg := key.Algorithm
+	if signerCfg.Alg != "" {
+		alg = signerCfg.Alg
+	}
+
 	signingKey := jose.SigningKey{
 		Key:       key.Key,
-		Algorithm: jose.SignatureAlgorithm(signerCfg.Alg),
+		Algorithm: jose.SignatureAlgorithm(alg),
 	}
 	opts := &jose.SignerOptions{
 		ExtraHeaders: map[jose.HeaderKey]interface{}{

--- a/jws.go
+++ b/jws.go
@@ -18,7 +18,7 @@ const (
 )
 
 type SignatureConfig struct {
-	Alg                string   `json:"alg"`
+	Alg                string   `json:"alg,omitempty"`
 	URI                string   `json:"jwk-url"`
 	CacheEnabled       bool     `json:"cache,omitempty"`
 	CacheDuration      uint32   `json:"cache_duration,omitempty"`
@@ -34,7 +34,7 @@ type SignatureConfig struct {
 }
 
 type SignerConfig struct {
-	Alg                string   `json:"alg,omitempty"`
+	Alg                string   `json:"alg"`
 	KeyID              string   `json:"kid"`
 	URI                string   `json:"jwk-url"`
 	FullSerialization  bool     `json:"full,omitempty"`


### PR DESCRIPTION
Hi,
I have a situation, which there are different JWKs with different algorithms. I sign my tokens with them in random style for more security, but in KrakenD for validating them I must declare the Alg attribute in the config, which can be replaced by the JWK algorithm as the default value.

So applying this change adds a lot of flexibility for validating the tokens.
