### PR TITLE
JWK cache initialized

### DIFF
--- a/jwk_test.go
+++ b/jwk_test.go
@@ -118,6 +118,11 @@ func TestJWK_cache(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
+		if hits != 1 {
+			t.Errorf("wrong initial number of hits to the jwk endpoint: %d", hits)
+		}
+
 		for i := 0; i < 10; i++ {
 			for _, k := range tc.ID {
 				key, err := secretProvidr.GetKey(k)


### PR DESCRIPTION
force an initial key request so the SecretProvider's cache gets initialized before starting the service