### PR TITLE
Add ability to propagate JWT claims as request headers

### DIFF
--- a/gin/jose.go
+++ b/gin/jose.go
@@ -127,9 +127,23 @@ func TokenSignatureValidator(hf ginkrakend.HandlerFactory, logger logging.Logger
 				return
 			}
 
+			propagateHeaders(cfg, scfg.PropagateClaimsToHeader, claims, c, logger)
+
 			paramExtractor(c, claims)
 
 			handler(c)
+		}
+	}
+}
+
+func propagateHeaders(cfg *config.EndpointConfig, propagationCfg [][]string, claims map[string]interface{}, c *gin.Context, logger logging.Logger) {
+	if len(propagationCfg) > 0 {
+		headersToPropagate, err := krakendjose.CalculateHeadersToPropagate(propagationCfg, claims)
+		if err != nil {
+			logger.Warning(fmt.Sprintf("JOSE: header propagations error for %s: %s", cfg.Endpoint, err.Error()))
+		}
+		for k, v := range headersToPropagate {
+			c.Request.Header.Add(k, v)
 		}
 	}
 }

--- a/gin/jose_example_test.go
+++ b/gin/jose_example_test.go
@@ -288,6 +288,7 @@ func newVerifierEndpointCfg(alg, URL string, roles []string) *config.EndpointCon
 				"audience":             []string{"http://api.example.com"},
 				"issuer":               "http://example.com",
 				"roles":                roles,
+				"propagate-claims":     [][]string{[]string{"jti", "x-krakend-jti"}, []string{"sub", "x-krakend-sub"}, []string{"nonexistend", "x-krakend-ne"}},
 				"disable_jwk_security": true,
 				"cache":                true,
 			},

--- a/gin/jose_example_test.go
+++ b/gin/jose_example_test.go
@@ -288,7 +288,7 @@ func newVerifierEndpointCfg(alg, URL string, roles []string) *config.EndpointCon
 				"audience":             []string{"http://api.example.com"},
 				"issuer":               "http://example.com",
 				"roles":                roles,
-				"propagate-claims":     [][]string{[]string{"jti", "x-krakend-jti"}, []string{"sub", "x-krakend-sub"}, []string{"nonexistend", "x-krakend-ne"}},
+				"propagate-claims":     [][]string{[]string{"jti", "x-krakend-jti"}, []string{"sub", "x-krakend-sub"}, []string{"nonexistent", "x-krakend-ne"}},
 				"disable_jwk_security": true,
 				"cache":                true,
 			},

--- a/gin/jose_test.go
+++ b/gin/jose_test.go
@@ -28,6 +28,9 @@ func TestTokenSignatureValidator(t *testing.T) {
 	registeredEndpointCfg.Endpoint = "/registered"
 	registeredEndpointCfg.Backend[0].URLPattern = "/{{.JWT.sub}}/{{.JWT.jti}}"
 
+	propagateHeadersEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{})
+	propagateHeadersEndpointCfg.Endpoint = "/propagateheaders"
+
 	token := "eyJhbGciOiJSUzI1NiIsImtpZCI6IjIwMTEtMDQtMjkifQ.eyJhdWQiOiJodHRwOi8vYXBpLmV4YW1wbGUuY29tIiwiZXhwIjoxNzM1Njg5NjAwLCJpc3MiOiJodHRwOi8vZXhhbXBsZS5jb20iLCJqdGkiOiJtbmIyM3Zjc3J0NzU2eXVpb21uYnZjeDk4ZXJ0eXVpb3AiLCJyb2xlcyI6WyJyb2xlX2EiLCJyb2xlX2IiXSwic3ViIjoiMTIzNDU2Nzg5MHF3ZXJ0eXVpbyJ9.NrLwxZK8UhS6CV2ijdJLUfAinpjBn5_uliZCdzQ7v-Dc8lcv1AQA9cYsG63RseKWH9u6-TqPKMZQ56WfhqL028BLDdQCiaeuBoLzYU1tQLakA1V0YmouuEVixWLzueVaQhyGx-iKuiuFhzHWZSqFqSehiyzI9fb5O6Gcc2L6rMEoxQMaJomVS93h-t013MNq3ADLWTXRaO-negydqax_WmzlVWp_RDroR0s5J2L2klgmBXVwh6SYy5vg7RrnuN3S8g4oSicJIi9NgnG-dDikuaOg2DeFUt-mYq_j_PbNXf9TUl5hl4kEy7E0JauJ17d1BUuTl3ChY4BOmhQYRN0dYg"
 
 	dummyProxy := func(ctx context.Context, req *proxy.Request) (*proxy.Response, error) {
@@ -73,6 +76,7 @@ func TestTokenSignatureValidator(t *testing.T) {
 	engine.GET(validatorEndpointCfg.Endpoint, hf(validatorEndpointCfg, dummyProxy))
 	engine.GET(forbidenEndpointCfg.Endpoint, hf(forbidenEndpointCfg, dummyProxy))
 	engine.GET(registeredEndpointCfg.Endpoint, hf(registeredEndpointCfg, assertProxy))
+	engine.GET(propagateHeadersEndpointCfg.Endpoint, hf(propagateHeadersEndpointCfg, dummyProxy))
 
 	req := httptest.NewRequest("GET", forbidenEndpointCfg.Endpoint, new(bytes.Buffer))
 
@@ -121,6 +125,35 @@ func TestTokenSignatureValidator(t *testing.T) {
 
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("unexpected status code: %d", w.Code)
+	}
+	if body := w.Body.String(); body != "{\"aaaa\":{\"bar\":\"b\",\"foo\":\"a\"},\"bbbb\":true,\"cccc\":1234567890}\n" {
+		t.Errorf("unexpected body: %s", body)
+	}
+
+	req = httptest.NewRequest("GET", propagateHeadersEndpointCfg.Endpoint, new(bytes.Buffer))
+	req.Header.Set("Authorization", "BEARER "+token)
+
+	w = httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	if req.Header.Get("x-krakend-jti") == "" {
+		t.Error("JWT claim not propagated to header: jti")
+	} else if req.Header.Get("x-krakend-jti") != "mnb23vcsrt756yuiomnbvcx98ertyuiop" {
+		t.Errorf("wrong JWT claim propagated for 'jti': %v", req.Header.Get("x-krakend-jti"))
+	}
+
+	if req.Header.Get("x-krakend-sub") == "" {
+		t.Error("JWT claim not propagated to header: sub")
+	} else if req.Header.Get("x-krakend-sub") != "1234567890qwertyuio" {
+		t.Errorf("wrong JWT claim propagated for 'sub': %v", req.Header.Get("x-krakend-sub"))
+	}
+
+	if req.Header.Get("x-krakend-ne") != "" {
+		t.Error("JWT claim propagated, although it shouldn't: nonexistend")
+	}
 
 	if w.Code != http.StatusOK {
 		t.Errorf("unexpected status code: %d", w.Code)

--- a/gin/jose_test.go
+++ b/gin/jose_test.go
@@ -152,7 +152,7 @@ func TestTokenSignatureValidator(t *testing.T) {
 	}
 
 	if req.Header.Get("x-krakend-ne") != "" {
-		t.Error("JWT claim propagated, although it shouldn't: nonexistend")
+		t.Error("JWT claim propagated, although it shouldn't: nonexistent")
 	}
 
 	if w.Code != http.StatusOK {

--- a/jose.go
+++ b/jose.go
@@ -132,6 +132,27 @@ func SignFields(keys []string, signer Signer, response *proxy.Response) error {
 	return nil
 }
 
+func CalculateHeadersToPropagate(propagationCfg [][]string, claims map[string]interface{}) (map[string]string, error) {
+	if len(propagationCfg) == 0 {
+		return nil, fmt.Errorf("JOSE: no headers to propagate. Config size: %d", len(propagationCfg))
+	}
+
+	propagated := make(map[string]string)
+
+	for _, tuple := range propagationCfg {
+		fromClaim := tuple[0]
+		toHeader := tuple[1]
+		tmp, ok := claims[fromClaim].(string)
+		if !ok {
+			continue
+		}
+		propagated[toHeader] = tmp
+	}
+
+	return propagated, nil
+
+}
+
 var supportedAlgorithms = map[string]jose.SignatureAlgorithm{
 	"EdDSA": jose.EdDSA,
 	"HS256": jose.HS256,

--- a/jws.go
+++ b/jws.go
@@ -18,20 +18,21 @@ const (
 )
 
 type SignatureConfig struct {
-	Alg                string   `json:"alg"`
-	URI                string   `json:"jwk-url"`
-	CacheEnabled       bool     `json:"cache,omitempty"`
-	CacheDuration      uint32   `json:"cache_duration,omitempty"`
-	Issuer             string   `json:"issuer,omitempty"`
-	Audience           []string `json:"audience,omitempty"`
-	Roles              []string `json:"roles,omitempty"`
-	RolesKey           string   `json:"roles_key,omitempty"`
-	RolesKeyIsNested   bool     `json:"roles_key_is_nested,omitempty"`
-	CookieKey          string   `json:"cookie_key,omitempty"`
-	CipherSuites       []uint16 `json:"cipher_suites,omitempty"`
-	DisableJWKSecurity bool     `json:"disable_jwk_security"`
-	Fingerprints       []string `json:"jwk_fingerprints,omitempty"`
-	LocalCA            string   `json:"jwk_local_ca,omitempty"`
+	Alg                     string     `json:"alg"`
+	URI                     string     `json:"jwk-url"`
+	CacheEnabled            bool       `json:"cache,omitempty"`
+	CacheDuration           uint32     `json:"cache_duration,omitempty"`
+	Issuer                  string     `json:"issuer,omitempty"`
+	Audience                []string   `json:"audience,omitempty"`
+	Roles                   []string   `json:"roles,omitempty"`
+	PropagateClaimsToHeader [][]string `json:"propagate-claims,omitempty"`
+	RolesKey                string     `json:"roles_key,omitempty"`
+	RolesKeyIsNested        bool       `json:"roles_key_is_nested,omitempty"`
+	CookieKey               string     `json:"cookie_key,omitempty"`
+	CipherSuites            []uint16   `json:"cipher_suites,omitempty"`
+	DisableJWKSecurity      bool       `json:"disable_jwk_security"`
+	Fingerprints            []string   `json:"jwk_fingerprints,omitempty"`
+	LocalCA                 string     `json:"jwk_local_ca,omitempty"`
 }
 
 type SignerConfig struct {

--- a/mux/jose_example_test.go
+++ b/mux/jose_example_test.go
@@ -268,7 +268,7 @@ func newVerifierEndpointCfg(alg, URL string, roles []string) *config.EndpointCon
 				"audience":             []string{"http://api.example.com"},
 				"issuer":               "http://example.com",
 				"roles":                roles,
-				"propagate-claims":     [][]string{[]string{"jti", "x-krakend-jti"}, []string{"sub", "x-krakend-sub"}, []string{"nonexistend", "x-krakend-ne"}},
+				"propagate-claims":     [][]string{[]string{"jti", "x-krakend-jti"}, []string{"sub", "x-krakend-sub"}, []string{"nonexistent", "x-krakend-ne"}},
 				"disable_jwk_security": true,
 				"cache":                true,
 			},

--- a/mux/jose_example_test.go
+++ b/mux/jose_example_test.go
@@ -268,6 +268,7 @@ func newVerifierEndpointCfg(alg, URL string, roles []string) *config.EndpointCon
 				"audience":             []string{"http://api.example.com"},
 				"issuer":               "http://example.com",
 				"roles":                roles,
+				"propagate-claims":     [][]string{[]string{"jti", "x-krakend-jti"}, []string{"sub", "x-krakend-sub"}, []string{"nonexistend", "x-krakend-ne"}},
 				"disable_jwk_security": true,
 				"cache":                true,
 			},

--- a/mux/jose_test.go
+++ b/mux/jose_test.go
@@ -26,6 +26,9 @@ func TestTokenSignatureValidator(t *testing.T) {
 	registeredEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{})
 	registeredEndpointCfg.Endpoint = "/registered"
 
+	propagateHeadersEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{})
+	propagateHeadersEndpointCfg.Endpoint = "/propagateheaders"
+
 	token := "eyJhbGciOiJSUzI1NiIsImtpZCI6IjIwMTEtMDQtMjkifQ.eyJhdWQiOiJodHRwOi8vYXBpLmV4YW1wbGUuY29tIiwiZXhwIjoxNzM1Njg5NjAwLCJpc3MiOiJodHRwOi8vZXhhbXBsZS5jb20iLCJqdGkiOiJtbmIyM3Zjc3J0NzU2eXVpb21uYnZjeDk4ZXJ0eXVpb3AiLCJyb2xlcyI6WyJyb2xlX2EiLCJyb2xlX2IiXSwic3ViIjoiMTIzNDU2Nzg5MHF3ZXJ0eXVpbyJ9.NrLwxZK8UhS6CV2ijdJLUfAinpjBn5_uliZCdzQ7v-Dc8lcv1AQA9cYsG63RseKWH9u6-TqPKMZQ56WfhqL028BLDdQCiaeuBoLzYU1tQLakA1V0YmouuEVixWLzueVaQhyGx-iKuiuFhzHWZSqFqSehiyzI9fb5O6Gcc2L6rMEoxQMaJomVS93h-t013MNq3ADLWTXRaO-negydqax_WmzlVWp_RDroR0s5J2L2klgmBXVwh6SYy5vg7RrnuN3S8g4oSicJIi9NgnG-dDikuaOg2DeFUt-mYq_j_PbNXf9TUl5hl4kEy7E0JauJ17d1BUuTl3ChY4BOmhQYRN0dYg"
 
 	dummyProxy := func(ctx context.Context, req *proxy.Request) (*proxy.Response, error) {
@@ -54,6 +57,7 @@ func TestTokenSignatureValidator(t *testing.T) {
 	engine.Handle(validatorEndpointCfg.Endpoint, "GET", hf(validatorEndpointCfg, dummyProxy))
 	engine.Handle(forbidenEndpointCfg.Endpoint, "GET", hf(forbidenEndpointCfg, dummyProxy))
 	engine.Handle(registeredEndpointCfg.Endpoint, "GET", hf(registeredEndpointCfg, dummyProxy))
+	engine.Handle(propagateHeadersEndpointCfg.Endpoint, "GET", hf(propagateHeadersEndpointCfg, dummyProxy))
 
 	req := httptest.NewRequest("GET", forbidenEndpointCfg.Endpoint, new(bytes.Buffer))
 
@@ -102,6 +106,35 @@ func TestTokenSignatureValidator(t *testing.T) {
 
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("unexpected status code: %d", w.Code)
+	}
+	if body := w.Body.String(); body != `{"aaaa":{"bar":"b","foo":"a"},"bbbb":true,"cccc":1234567890}` {
+		t.Errorf("unexpected body: %s", body)
+	}
+
+	req = httptest.NewRequest("GET", propagateHeadersEndpointCfg.Endpoint, new(bytes.Buffer))
+	req.Header.Set("Authorization", "BEARER "+token)
+
+	w = httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	if req.Header.Get("x-krakend-jti") == "" {
+		t.Error("JWT claim not propagated to header: jti")
+	} else if req.Header.Get("x-krakend-jti") != "mnb23vcsrt756yuiomnbvcx98ertyuiop" {
+		t.Errorf("wrong JWT claim propagated for 'jti': %v", req.Header.Get("x-krakend-jti"))
+	}
+
+	if req.Header.Get("x-krakend-sub") == "" {
+		t.Error("JWT claim not propagated to header: sub")
+	} else if req.Header.Get("x-krakend-sub") != "1234567890qwertyuio" {
+		t.Errorf("wrong JWT claim propagated for 'sub': %v", req.Header.Get("x-krakend-sub"))
+	}
+
+	if req.Header.Get("x-krakend-ne") != "" {
+		t.Error("JWT claim propagated, although it shouldn't: nonexistend")
+	}
 
 	if w.Code != http.StatusOK {
 		t.Errorf("unexpected status code: %d", w.Code)

--- a/mux/jose_test.go
+++ b/mux/jose_test.go
@@ -133,7 +133,7 @@ func TestTokenSignatureValidator(t *testing.T) {
 	}
 
 	if req.Header.Get("x-krakend-ne") != "" {
-		t.Error("JWT claim propagated, although it shouldn't: nonexistend")
+		t.Error("JWT claim propagated, although it shouldn't: nonexistent")
 	}
 
 	if w.Code != http.StatusOK {


### PR DESCRIPTION
This pull request enables the functionality to forward claims in a JWT as request headers. It is a common use case to e.g. have the `sub` claim added as a `X-User` header to the request. This can be enabled by this PR. I added a new configuration option to the krakend-jose component ("propagate-claims") which takes an array of "claim/header" values, describing how to map which claim to which header value. Sample:

```json
"extra_config": {
        "github.com/devopsfaith/krakend-jose/validator": {
          ...
          ...
          "propagate-claims": [
            ["sub", "x-user"]
          ]
          ...
          ...
        }
      },
```

In this case, the value of the `sub` claim will be added as `x-user` header to the request. If the claim does not exists, the mapping is just skipped.

Tests have been added.

Important: to have the headers forwarded to the backend, you also need to add them to the `headers_to_pass` property of the endpoint.

This also could have been done by using a Lua script, but the performance would be really poor, especially compared to this approach.
