### PR TITLE
Add JWT scopes validation

### DIFF
--- a/jose_test.go
+++ b/jose_test.go
@@ -132,3 +132,166 @@ func TestCanAccessNested(t *testing.T) {
 		})
 	}
 }
+
+func TestScopesAllMatcher(t *testing.T) {
+	for _, v := range []struct {
+		name           string
+		scopesKey      string
+		claims         map[string]interface{}
+		requiredScopes []string
+		expected       bool
+	}{
+		{
+			name:           "all_simple_success",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": "a b"},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
+			name:           "all_simple_fail",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": "a b"},
+			requiredScopes: []string{"c"},
+			expected:       false,
+		},
+		{
+			name:           "all_missingone_fail",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": "a b"},
+			requiredScopes: []string{"a", "b", "c"},
+			expected:       false,
+		},
+		{
+			name:           "all_one_simple_success",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": "a b"},
+			requiredScopes: []string{"b"},
+			expected:       true,
+		},
+		{
+			name:           "all_no_req_scopes_success",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": "a b"},
+			requiredScopes: []string{},
+			expected:       true,
+		},
+		{
+			name:           "all_struct_success",
+			scopesKey:      "data.scope",
+			claims:         map[string]interface{}{"data": map[string]interface{}{"scope": "a b"}},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
+			name:      "all_deep_struct_success",
+			scopesKey: "data.data.data.data.data.data.data.scope",
+			claims: map[string]interface{}{
+				"data": map[string]interface{}{
+					"data": map[string]interface{}{
+						"data": map[string]interface{}{
+							"data": map[string]interface{}{
+								"data": map[string]interface{}{
+									"data": map[string]interface{}{
+										"data": map[string]interface{}{
+											"scope": "a b",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+	} {
+		t.Run(v.name, func(t *testing.T) {
+			if res := ScopesAllMatcher(v.scopesKey, v.claims, v.requiredScopes); res != v.expected {
+				t.Errorf("'%s' have %v, want %v", v.name, res, v.expected)
+			}
+		})
+	}
+}
+func TestScopesAnyMatcher(t *testing.T) {
+	for _, v := range []struct {
+		name           string
+		scopesKey      string
+		claims         map[string]interface{}
+		requiredScopes []string
+		expected       bool
+	}{
+		{
+			name:           "any_simple_success",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": "a b"},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
+			name:           "any_simple_fail",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": "a b"},
+			requiredScopes: []string{"c"},
+			expected:       false,
+		},
+		{
+			name:           "any_missingone_success",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": "a"},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
+			name:           "any_one_simple_success",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": "a b"},
+			requiredScopes: []string{"b"},
+			expected:       true,
+		},
+		{
+			name:           "any_no_req_scopes_success",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": "a b"},
+			requiredScopes: []string{},
+			expected:       true,
+		},
+		{
+			name:           "any_struct_success",
+			scopesKey:      "data.scope",
+			claims:         map[string]interface{}{"data": map[string]interface{}{"scope": "a"}},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
+			name:      "any_deep_struct_success",
+			scopesKey: "data.data.data.data.data.data.data.scope",
+			claims: map[string]interface{}{
+				"data": map[string]interface{}{
+					"data": map[string]interface{}{
+						"data": map[string]interface{}{
+							"data": map[string]interface{}{
+								"data": map[string]interface{}{
+									"data": map[string]interface{}{
+										"data": map[string]interface{}{
+											"scope": "a",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+	} {
+		t.Run(v.name, func(t *testing.T) {
+			if res := ScopesAnyMatcher(v.scopesKey, v.claims, v.requiredScopes); res != v.expected {
+				t.Errorf("'%s' have %v, want %v", v.name, res, v.expected)
+			}
+		})
+	}
+}

--- a/jws.go
+++ b/jws.go
@@ -36,6 +36,9 @@ type SignatureConfig struct {
 	LocalPath               string     `json:"jwk_local_path,omitempty"`
 	SecretURL               string     `json:"secret_url,omitempty"`
 	CipherKey               []byte     `json:"cypher_key,omitempty"`
+	Scopes                  []string   `json:"scopes,omitempty"`
+	ScopesKey               string     `json:"scopes_key,omitempty"`
+	ScopesMatcher           string     `json:"scopes_matcher,omitempty"`
 }
 
 type SignerConfig struct {


### PR DESCRIPTION
This PR adds the ability to validate scopes in a JWT token. The key for the scopes claim can be customized ("scopes_key" property) and the value can be read from a nested property in the token (same as for "role" validation). Additionally, the matching function can be customized: "any" returns "true" when at least one of the required scopes is available in the token, "all" means that all required scopes need to be included.

If the validation fails, a 403 will be returned.

Tests have been added.