### PR TITLE
JWT/header propagation: replace existing values

### DIFF
--- a/gin/jose.go
+++ b/gin/jose.go
@@ -160,7 +160,8 @@ func propagateHeaders(cfg *config.EndpointConfig, propagationCfg [][]string, cla
 			logger.Warning(fmt.Sprintf("JOSE: header propagations error for %s: %s", cfg.Endpoint, err.Error()))
 		}
 		for k, v := range headersToPropagate {
-			c.Request.Header.Add(k, v)
+			// Set header value - replaces existing one
+			c.Request.Header.Set(k, v)
 		}
 	}
 }

--- a/gin/jose_example_test.go
+++ b/gin/jose_example_test.go
@@ -288,7 +288,7 @@ func newVerifierEndpointCfg(alg, URL string, roles []string) *config.EndpointCon
 				"audience":             []string{"http://api.example.com"},
 				"issuer":               "http://example.com",
 				"roles":                roles,
-				"propagate-claims":     [][]string{{"jti", "x-krakend-jti"}, {"sub", "x-krakend-sub"}, {"nonexistent", "x-krakend-ne"}},
+				"propagate-claims":     [][]string{{"jti", "x-krakend-jti"}, {"sub", "x-krakend-sub"}, {"nonexistent", "x-krakend-ne"}, {"sub", "x-krakend-replace"}},
 				"disable_jwk_security": true,
 				"cache":                true,
 			},

--- a/gin/jose_test.go
+++ b/gin/jose_test.go
@@ -141,6 +141,8 @@ func TestTokenSignatureValidator(t *testing.T) {
 
 	req = httptest.NewRequest("GET", propagateHeadersEndpointCfg.Endpoint, new(bytes.Buffer))
 	req.Header.Set("Authorization", "BEARER "+token)
+	// Check header-overwrite: it must be overwritten by a claim in the JWT!
+	req.Header.Set("x-krakend-replace", "abc")
 
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
@@ -149,6 +151,13 @@ func TestTokenSignatureValidator(t *testing.T) {
 		t.Error("JWT claim not propagated to header: jti")
 	} else if req.Header.Get("x-krakend-jti") != "mnb23vcsrt756yuiomnbvcx98ertyuiop" {
 		t.Errorf("wrong JWT claim propagated for 'jti': %v", req.Header.Get("x-krakend-jti"))
+	}
+
+	// Check that existing header values are overwritten
+	if req.Header.Get("x-krakend-replace") == "abc" {
+		t.Error("JWT claim not propagated to x-krakend-replace header: sub")
+	} else if req.Header.Get("x-krakend-replace") != "1234567890qwertyuio" {
+		t.Errorf("wrong JWT claim propagated for 'sub': %v", req.Header.Get("x-krakend-replace"))
 	}
 
 	if req.Header.Get("x-krakend-sub") == "" {

--- a/mux/jose.go
+++ b/mux/jose.go
@@ -192,8 +192,8 @@ func propagateHeaders(cfg *config.EndpointConfig, propagationCfg [][]string, cla
 			logger.Warning(fmt.Sprintf("JOSE: header propagations error for %s: %s", cfg.Endpoint, err.Error()))
 		}
 		for k, v := range headersToPropagate {
-			r.Header.Add(k, v)
-
+			// Set header value - replaces existing one
+			r.Header.Set(k, v)
 		}
 	}
 }

--- a/mux/jose_example_test.go
+++ b/mux/jose_example_test.go
@@ -268,7 +268,7 @@ func newVerifierEndpointCfg(alg, URL string, roles []string) *config.EndpointCon
 				"audience":             []string{"http://api.example.com"},
 				"issuer":               "http://example.com",
 				"roles":                roles,
-				"propagate-claims":     [][]string{{"jti", "x-krakend-jti"}, {"sub", "x-krakend-sub"}, {"nonexistent", "x-krakend-ne"}},
+				"propagate-claims":     [][]string{{"jti", "x-krakend-jti"}, {"sub", "x-krakend-sub"}, {"nonexistent", "x-krakend-ne"}, {"sub", "x-krakend-replace"}},
 				"disable_jwk_security": true,
 				"cache":                true,
 			},

--- a/mux/jose_test.go
+++ b/mux/jose_test.go
@@ -116,6 +116,8 @@ func TestTokenSignatureValidator(t *testing.T) {
 
 	req = httptest.NewRequest("GET", propagateHeadersEndpointCfg.Endpoint, new(bytes.Buffer))
 	req.Header.Set("Authorization", "BEARER "+token)
+	// Check header-overwrite: it must be overwritten by a claim in the JWT!
+	req.Header.Set("x-krakend-replace", "abc")
 
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
@@ -124,6 +126,13 @@ func TestTokenSignatureValidator(t *testing.T) {
 		t.Error("JWT claim not propagated to header: jti")
 	} else if req.Header.Get("x-krakend-jti") != "mnb23vcsrt756yuiomnbvcx98ertyuiop" {
 		t.Errorf("wrong JWT claim propagated for 'jti': %v", req.Header.Get("x-krakend-jti"))
+	}
+
+	// Check that existing header values are overwritten
+	if req.Header.Get("x-krakend-replace") == "abc" {
+		t.Error("JWT claim not propagated to x-krakend-replace header: sub")
+	} else if req.Header.Get("x-krakend-replace") != "1234567890qwertyuio" {
+		t.Errorf("wrong JWT claim propagated for 'sub': %v", req.Header.Get("x-krakend-replace"))
 	}
 
 	if req.Header.Get("x-krakend-sub") == "" {


### PR DESCRIPTION
When propagating JWT claims to header values, replace values from
headers that already exist instead of appending the claims.

Fixes #62 