### PR TITLE
serialize the claims after extracting them

### DIFF
--- a/gin/jose.go
+++ b/gin/jose.go
@@ -183,12 +183,15 @@ func extractRequiredJWTClaims(cfg *config.EndpointConfig) func(*gin.Context, map
 	}
 
 	return func(c *gin.Context, claims map[string]interface{}) {
+		cl := krakendjose.Claims(claims)
 		for _, param := range required {
 			// TODO: check for nested claims
-			if v, ok := claims[param].(string); ok {
-				params := append(c.Params, gin.Param{Key: "JWT." + param, Value: v})
-				c.Params = params
+			v, ok := cl.Get(param)
+			if !ok {
+				continue
 			}
+			params := append(c.Params, gin.Param{Key: "JWT." + param, Value: v})
+			c.Params = params
 		}
 	}
 }

--- a/jose.go
+++ b/jose.go
@@ -1,6 +1,7 @@
 package jose
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -236,6 +237,36 @@ func SignFields(keys []string, signer Signer, response *proxy.Response) error {
 	return nil
 }
 
+type Claims map[string]interface{}
+
+func (c Claims) Get(name string) (string, bool) {
+	tmp, ok := c[name]
+	if !ok {
+		return "", ok
+	}
+
+	var normalized string
+
+	switch v := tmp.(type) {
+	case string:
+		normalized = v
+	case int:
+		normalized = fmt.Sprintf("%d", v)
+	case float64:
+		normalized = fmt.Sprintf("%f", v)
+	case []interface{}:
+		normalized = fmt.Sprintf("%v", v[0])
+		for _, elem := range v[1:] {
+			normalized += fmt.Sprintf(",%v", elem)
+		}
+	default:
+		b, _ := json.Marshal(v)
+		normalized = string(b)
+	}
+
+	return normalized, ok
+}
+
 func CalculateHeadersToPropagate(propagationCfg [][]string, claims map[string]interface{}) (map[string]string, error) {
 	if len(propagationCfg) == 0 {
 		return nil, fmt.Errorf("JOSE: no headers to propagate. Config size: %d", len(propagationCfg))
@@ -243,14 +274,16 @@ func CalculateHeadersToPropagate(propagationCfg [][]string, claims map[string]in
 
 	propagated := make(map[string]string)
 
+	c := Claims(claims)
+
 	for _, tuple := range propagationCfg {
 		fromClaim := tuple[0]
 		toHeader := tuple[1]
-		tmp, ok := claims[fromClaim].(string)
+		v, ok := c.Get(fromClaim)
 		if !ok {
 			continue
 		}
-		propagated[toHeader] = tmp
+		propagated[toHeader] = v
 	}
 
 	return propagated, nil

--- a/jose_test.go
+++ b/jose_test.go
@@ -2,6 +2,7 @@ package jose
 
 import (
 	"net/http"
+	"reflect"
 	"testing"
 
 	"gopkg.in/square/go-jose.v2/jwt"
@@ -293,5 +294,38 @@ func TestScopesAnyMatcher(t *testing.T) {
 				t.Errorf("'%s' have %v, want %v", v.name, res, v.expected)
 			}
 		})
+	}
+}
+
+func TestCalculateHeadersToPropagate(t *testing.T) {
+	for i, tc := range []struct {
+		cfg      [][]string
+		claims   map[string]interface{}
+		expected map[string]string
+	}{
+		{
+			cfg: [][]string{{"a", "x-a"}, {"b", "x-b"}, {"c", "x-c"}, {"d", "x-d"}},
+			claims: map[string]interface{}{
+				"a": 1,
+				"b": "foo",
+				"c": []interface{}{"one", "two"},
+				"d": map[string]interface{}{
+					"a": 1,
+					"b": "foo",
+					"c": []interface{}{"one", "two"},
+				},
+			},
+			expected: map[string]string{"x-a": "1", "x-b": "foo", "x-c": "one,two", "x-d": `{"a":1,"b":"foo","c":["one","two"]}`},
+		},
+	} {
+		res, err := CalculateHeadersToPropagate(tc.cfg, tc.claims)
+		if err != nil {
+			t.Errorf("tc-%d: unexpected error: %v", i, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(tc.expected, res) {
+			t.Errorf("tc-%d: unexpected response: %v", i, res)
+		}
 	}
 }


### PR DESCRIPTION
This PR adds support for extracting claims containing other than strings. Serialization by type:
- strings: as is
- integers and floats: simple %d and %f representation
- arrays: string containing a comma-separated set of values
- others: json

The serialization applies to both claim extractors (params and headers)