### PR TITLE
Allow the propagation of nested claims using dot notation

### DIFF
--- a/jose.go
+++ b/jose.go
@@ -246,7 +246,15 @@ func CalculateHeadersToPropagate(propagationCfg [][]string, claims map[string]in
 	for _, tuple := range propagationCfg {
 		fromClaim := tuple[0]
 		toHeader := tuple[1]
-		tmp, ok := claims[fromClaim].(string)
+
+		tmpClaims := claims
+		tmpKey := fromClaim
+
+		if strings.Contains(fromClaim, ".") {
+			tmpKey, tmpClaims = getNestedClaim(fromClaim, claims)
+		}
+
+		tmp, ok := tmpClaims[tmpKey].(string)
 		if !ok {
 			continue
 		}

--- a/jose.go
+++ b/jose.go
@@ -250,7 +250,7 @@ func CalculateHeadersToPropagate(propagationCfg [][]string, claims map[string]in
 		tmpClaims := claims
 		tmpKey := fromClaim
 
-		if strings.Contains(fromClaim, ".") {
+		if strings.Contains(fromClaim, ".") && fromClaim[:4] != "http" {
 			tmpKey, tmpClaims = getNestedClaim(fromClaim, claims)
 		}
 


### PR DESCRIPTION
Given a JWT like

```json
{
  "sub": "1234567890",
  "name": "John Doe",
  "iat": 1516239022,
  "customClaim": {
     "nested": "value"
  }
}
```

then this PR allows the propagation of a nested claim to a header using dot notation, like

```json
"github.com/devopsfaith/krakend-jose/validator": {
    "propagate-claims": [
        ["customClaim.nested", "X-Nested-Claim"]
    ]
}
```