### PR TITLE
Fix the file key cacher constructor

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -107,7 +107,8 @@ func NewFileKeyCacher(data []byte, keyIdentifyStrategy string) (*FileKeyCacher, 
 	keyMap := map[string]*jose.JSONWebKey{}
 	keyIDGetter := KeyIDGetterFactory(keyIdentifyStrategy)
 	for _, k := range keys.Keys {
-		keyMap[keyIDGetter.Get(&k)] = &k
+		keyToStore := k
+		keyMap[keyIDGetter.Get(&keyToStore)] = &keyToStore
 	}
 	return &FileKeyCacher{keys: keyMap}, nil
 }

--- a/key_cacher.go
+++ b/key_cacher.go
@@ -3,8 +3,9 @@ package jose
 import (
 	b64 "encoding/base64"
 	"errors"
-	"gopkg.in/square/go-jose.v2"
 	"time"
+
+	"gopkg.in/square/go-jose.v2"
 )
 
 var (


### PR DESCRIPTION
copy the key before adding it to the key mapper, so the latter doesn't override all the other entries