### PR TITLE
Fix float normalization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/auth0-community/go-auth0 v1.0.0
 	github.com/gin-gonic/gin v1.7.7
-	github.com/luraproject/lura/v2 v2.0.2
+	github.com/luraproject/lura/v2 v2.0.4
 	gocloud.dev v0.20.0
 	gocloud.dev/secrets/hashivault v0.20.0
 	gopkg.in/square/go-jose.v2 v2.5.1
@@ -63,7 +63,6 @@ require (
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -260,10 +260,10 @@ github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgx
 github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/luraproject/lura/v2 v2.0.0 h1:nfIr4a8XLMECaPQBpGSWxXhNAya7JQwGa3kzLRy5z14=
-github.com/luraproject/lura/v2 v2.0.0/go.mod h1:1FhL+5a9uH6o7zMNstXlcjznL5yt2lZ9Q8efanmvw9w=
 github.com/luraproject/lura/v2 v2.0.2 h1:CA6ITvGa6xirW3Kj5XTZ8+dgUumKaEy9R/h/IGlZW3I=
 github.com/luraproject/lura/v2 v2.0.2/go.mod h1:1FhL+5a9uH6o7zMNstXlcjznL5yt2lZ9Q8efanmvw9w=
+github.com/luraproject/lura/v2 v2.0.4 h1:Syf7TjWj7pjTvt4BvHHXDHLBxEVuGT2G3PZ4Kzxf5R4=
+github.com/luraproject/lura/v2 v2.0.4/go.mod h1:1FhL+5a9uH6o7zMNstXlcjznL5yt2lZ9Q8efanmvw9w=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-ieproxy v0.0.0-20190702010315-6dee0af9227d/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
@@ -420,7 +420,6 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/jose.go
+++ b/jose.go
@@ -3,6 +3,7 @@ package jose
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"strings"
 
@@ -239,6 +240,8 @@ func SignFields(keys []string, signer Signer, response *proxy.Response) error {
 
 type Claims map[string]interface{}
 
+const epsilon = 1e-6
+
 func (c Claims) Get(name string) (string, bool) {
 	tmp, ok := c[name]
 	if !ok {
@@ -253,7 +256,10 @@ func (c Claims) Get(name string) (string, bool) {
 	case int:
 		normalized = fmt.Sprintf("%d", v)
 	case float64:
-		normalized = fmt.Sprintf("%v", v)
+		if r := math.Round(v); math.Abs(v-r) <= epsilon {
+			return fmt.Sprintf("%d", int(r)), ok
+		}
+		normalized = fmt.Sprintf("%f", v)
 	case []interface{}:
 		normalized = fmt.Sprintf("%v", v[0])
 		for _, elem := range v[1:] {

--- a/jose_test.go
+++ b/jose_test.go
@@ -347,7 +347,11 @@ func TestUnmarshalDataTypesGetClaim(t *testing.T) {
 		"t3_float": -42.42,
 		"t4_string": "string val",
 		"t5_string": "d0052a8b-6b35-4cb4-af69-b95e241e7208",
-		"t6_array": ["item 1", "item-2", 1, -2, 2.99, -3.01]
+		"t6_array": ["item 1", "item-2", 1, -2, 2.99, -3.01],
+		"t7_big_int": 1000001,
+		"t8_float_round": 4.000001,
+		"t9_float_round": 4.0000001,
+		"t10_timestamp": 1651529725
 	}`), &c)
 
 	for i, tc := range []struct {
@@ -368,7 +372,7 @@ func TestUnmarshalDataTypesGetClaim(t *testing.T) {
 		},
 		{
 			key:      "t3_float",
-			expected: "-42.42",
+			expected: "-42.420000",
 		},
 		{
 			key:      "t4_string",
@@ -382,10 +386,28 @@ func TestUnmarshalDataTypesGetClaim(t *testing.T) {
 			key:      "t6_array",
 			expected: "item 1,item-2,1,-2,2.99,-3.01",
 		},
+		{
+			key:      "t7_big_int",
+			expected: "1000001",
+		},
+		{
+			key:      "t8_float_round",
+			expected: "4.000001",
+		},
+		{
+			key:      "t9_float_round",
+			expected: "4",
+		},
+		{
+			key:      "t10_timestamp",
+			expected: "1651529725",
+		},
 	} {
-		res, ok := c.Get(tc.key)
-		if !ok || !reflect.DeepEqual(tc.expected, res) {
-			t.Errorf("Test %d - Claim %s: unexpected value: %v", i, tc.key, res)
-		}
+		t.Run(tc.key, func(t *testing.T) {
+			res, ok := c.Get(tc.key)
+			if !ok || !reflect.DeepEqual(tc.expected, res) {
+				t.Errorf("Test %d - Claim %s: unexpected value: %v", i, tc.key, res)
+			}
+		})
 	}
 }


### PR DESCRIPTION
this PR fixes the bug reported at https://github.com/devopsfaith/krakend-jose/pull/85#issuecomment-1113550033 by @lwohlhart

Important details:
- floats with very small distances (epsilon <= 1e-6) from their `math.Round` equivalent are replaced by the rounded value.
- big integers are kept as integers and are not converter to their exponential/engineering representation